### PR TITLE
Make version part of metadata.json

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,6 +1,29 @@
-#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+
 print("""
-### IMPORTANT###
-Register your app NOW by making a pull request to the AiiDA Lab App Registry
+Congratulations!
+You have now taken the first step in creating your new AiiDA Lab App:
+
+    {{cookiecutter.app_title}}
+
+### NEXT STEPS ###
+
+1. Open your new AiiDA Lab App folder
+
+    cd {{cookiecutter.repo_name}}
+
+2. Enable version control
+
+    git init
+
+3. Enable code sanity checks on every commit (recommended)
+
+    pip install -U pre-commit
+    pre-commit install
+
+4. Register your app NOW by making a pull request to the AiiDA Lab App Registry
 on https://github.com/aiidalab/aiidalab-registry
+See this link also for a full list of keys for your metadata.json file.
 """)

--- a/{{cookiecutter.repo_name}}/.gitignore
+++ b/{{cookiecutter.repo_name}}/.gitignore
@@ -5,3 +5,5 @@
 *~
 *.egg*
 .DS_Store
+
+.vscode

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -3,14 +3,14 @@
  
 # yapf = yet another python formatter
 - repo: git://github.com/pre-commit/mirrors-yapf
-  sha: v0.17.0
+  rev: v0.26.0
   hooks:
   - id: yapf
     language: system
 
 # prospector: collection of python linters
 - repo: git://github.com/guykisel/prospector-mirror
-  sha: b27f281eb9398fc8504415d7fbdabf119ea8c5e1
+  rev: 7ff847e779347033ebbd9e3b88279e7f3a998b45
   hooks:
   - id: prospector
     language: system

--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -11,7 +11,7 @@ addons:
   postgresql: "9.5"
 
 install:
-# Upgrade pip setuptools and wheel
+# Upgrade pip, setuptools, and wheel
 - pip install -U pip wheel setuptools
 - pip install -r requirements.txt
 

--- a/{{cookiecutter.repo_name}}/README.md
+++ b/{{cookiecutter.repo_name}}/README.md
@@ -9,7 +9,7 @@ This jupyter-based app is intended to run in
 as well as inside the
 [Quantum Mobile](https://materialscloud.org/work/quantum-mobile) Virtual Machine.
 
-Use the App Store in the Home App to install it.
+Use the App Store to install it.
 
 ## Usage
 

--- a/{{cookiecutter.repo_name}}/__init__.py
+++ b/{{cookiecutter.repo_name}}/__init__.py
@@ -1,7 +1,7 @@
+# -*- coding: utf-8 -*-
 """
-{{cookiecutter.app_name}}
+{{cookiecutter.app_title}}
+{{cookiecutter.repo_name}}
 
 {{cookiecutter.short_description}}
 """
-
-__version__ = "{{cookiecutter.version}}"

--- a/{{cookiecutter.repo_name}}/metadata.json
+++ b/{{cookiecutter.repo_name}}/metadata.json
@@ -1,6 +1,7 @@
 {
     "title": "{{cookiecutter.app_title}}",
     "description": "{{cookiecutter.short_description}}",
+    "version": "{{cookiecutter.version}}",
     "authors": "{{cookiecutter.author}}",
     "logo": "img/logo.png",
     "state": "development"

--- a/{{cookiecutter.repo_name}}/start.py
+++ b/{{cookiecutter.repo_name}}/start.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import ipywidgets as ipw
 
 template = """


### PR DESCRIPTION
#### Version in `metadata.json`
To be able to do versioning of AiiDA Lab apps properly, a `version` key is added to `metadata.json`.
The default is still "0.1-alpha".

~~In the new AiiDA Lab app's `__init__.py` file, the `__version__` is set from the new `version` value in `metadata.json`.
This is done in order to only ever have to change the version in a single place (`metadata.json`).~~
_Edit_: `__version__` is removed from `__init__.py`.

#### Minor fixes
Update pre-commit key (`sha` is now `rev`) and up versions of hooks.
Update `.gitignore`.
~~Update `.travis.yml` files with `--no-use-pep517` when doing `pip install`.~~
_Edit_: A larger rewrite of `.travis.yml` was undertaken in PR #7.